### PR TITLE
Bump keepass 1.x package to v1.28

### DIFF
--- a/keepassx/keepassx.nuspec
+++ b/keepassx/keepassx.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>keepassx</id>
 		<title>KeePass Classic Password Safe</title>
-		<version>1.27</version>
+		<version>1.28</version>
 		<authors>Dominik Reichl</authors>
 		<owners>Redsandro</owners>
 		<summary>This version of the popular KeePass password manager is compatible with KeePassX for Linux and OSX.</summary>

--- a/keepassx/tools/chocolateyInstall.ps1
+++ b/keepassx/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 $name = 'KeePass Classic'
-$url = 'http://downloads.sourceforge.net/keepass/KeePass-1.27-Setup.exe'
+$url = 'http://downloads.sourceforge.net/keepass/KeePass-1.28-Setup.exe'
 try {
 	Install-ChocolateyPackage $name 'EXE' '/VERYSILENT' $url
 	Write-ChocolateySuccess $name


### PR DESCRIPTION
KeePass 1.28 has been released.

BTW, I have a suggestion for you: Would you like to move this package to the automatic packages maintained by the core team (https://github.com/chocolatey/chocolatey-coreteampackages)?

The core team packages get nearly instant updates (because the Ketarin update process runs every hour).
